### PR TITLE
fix(a19): respecting default standalone flag since angular 19

### DIFF
--- a/libs/ng-mocks/src/index.ts
+++ b/libs/ng-mocks/src/index.ts
@@ -4,6 +4,7 @@ import './lib/common/ng-mocks-stack';
 import './lib/common/ng-mocks-global-overrides';
 
 export * from './lib/common/core.tokens';
+export * from './lib/common/func.is-standalone';
 
 export { getTestBedInjection, getInjection } from './lib/common/core.helpers';
 

--- a/libs/ng-mocks/src/lib/common/func.is-standalone.ts
+++ b/libs/ng-mocks/src/lib/common/func.is-standalone.ts
@@ -1,3 +1,5 @@
+import { VERSION } from '@angular/core';
+
 import collectDeclarations from '../resolve/collect-declarations';
 
 import { getNgType } from './func.get-ng-type';
@@ -11,5 +13,11 @@ export function isStandalone(declaration: any): boolean {
     return false;
   }
 
-  return collectDeclarations(declaration)[type].standalone === true;
+  // Handle Angular 19+ default standalone behavior
+  const declarations = collectDeclarations(declaration);
+  if (Number(VERSION.major) >= 19 && type !== 'NgModule' && declarations[type].standalone === undefined) {
+    return true;
+  }
+
+  return declarations[type].standalone === true;
 }

--- a/libs/ng-mocks/src/lib/mock-render/func.create-wrapper.ts
+++ b/libs/ng-mocks/src/lib/mock-render/func.create-wrapper.ts
@@ -140,6 +140,7 @@ export default (
     selector: 'mock-render',
     template: mockTemplate,
     viewProviders: flags.viewProviders,
+    standalone: false,
   };
 
   ctor = generateWrapperComponent({ ...meta, bindings, options });

--- a/tests/func.is-standalone.spec.ts
+++ b/tests/func.is-standalone.spec.ts
@@ -1,0 +1,30 @@
+import { Component, VERSION } from '@angular/core';
+
+import { isStandalone } from 'ng-mocks';
+
+@Component({
+  selector: 'standalone',
+  template: `<div>
+    <h1>Angular 19 standalone</h1>
+  </div>`,
+})
+class StandaloneComponent {}
+
+describe('func.is-standalone', () => {
+  describe('Angular 19+ specific tests', () => {
+    let originalMajor: string = VERSION.major;
+    const setVersionMajor = (major: number) => {
+      originalMajor = VERSION.major;
+      Object.assign(VERSION, { ...VERSION, major: major.toString() });
+    };
+
+    afterEach(() => {
+      Object.assign(VERSION, { ...VERSION, major: originalMajor });
+    });
+
+    it('should return true when standalone is undefined', () => {
+      setVersionMajor(19);
+      expect(isStandalone(StandaloneComponent)).toBeTruthy();
+    });
+  });
+});


### PR DESCRIPTION
Added standalone false as default for mock-render and updated isStandalone method to handle angular 19+ default standalone behavior for components.